### PR TITLE
feat(basic): Add message template.

### DIFF
--- a/__tests__/first-test.spec.ts
+++ b/__tests__/first-test.spec.ts
@@ -1,5 +1,0 @@
-describe("#First test", () => {
-  it("should pass if set up correctly", () => {
-    expect(1).toBe(1);
-  });
-});

--- a/__tests__/simple-logger.spec.ts
+++ b/__tests__/simple-logger.spec.ts
@@ -9,33 +9,37 @@ import logger from "../src/simple-logger";
 describe("#BasicLogger", () => {
   const testLogsDir = join(__dirname, TEST_LOG_DIR);
   const testFilePath = join(testLogsDir, "basic-test.json");
+  const realDate = Date.now;
 
   beforeAll(() => {
     if (!existsSync(testLogsDir)) {
       mkdirSync(join(__dirname, "logs"));
     }
+    global.Date.now = jest.fn(() => new Date("2019-04-07T10:20:30Z").getTime());
     logger.triggerLogger(testFilePath, { message: "Hello world!" });
   });
 
   afterAll(() => {
     unlinkSync(testFilePath);
+    global.Date.now = realDate;
   });
 
-  it("should open a new JSON file when called", async (done) => {
+  it("should open a new JSON file when called", async () => {
     const data = await doReadFile(testFilePath);
 
     expect(data).toBeDefined();
-    done();
   });
 
-  it("should contain an expected JSON in file", async (done) => {
+  it("should contain an expected JSON in file", async () => {
     const data = await doReadFile(testFilePath);
-    const expectedResult = JSON.stringify({
-      message: "Hello world!",
-    });
+    const result = JSON.parse(data);
 
-    expect(data).toBe(expectedResult);
-    done();
+    const expectedResult = {
+      message: "Hello world!",
+      timestamp: "2019-04-07T10:20:30.000Z",
+      level: "INFO",
+    };
+    expect(result).toStrictEqual(expectedResult);
   });
 
   it("should open two files if logger triggered twice", async () => {
@@ -49,17 +53,6 @@ describe("#BasicLogger", () => {
     expect(files).toContain("basic-test.json");
 
     unlinkSync(join(testLogsDir, "another-test.json"));
-  });
-
-  it("should overwrite file if it already exists", async () => {
-    logger.triggerLogger(testFilePath, { message: "Holà!!!!" });
-
-    const data = await doReadFile(testFilePath);
-    const expectedResult = JSON.stringify({
-      message: "Holà!!!!",
-    });
-
-    expect(data).toBe(expectedResult);
   });
 
   it("should build a file path from the logs directory and the file path name", () => {
@@ -81,5 +74,16 @@ describe("#BasicLogger", () => {
     const result = logger.buildFileName("2020-10-05", "basic-test");
 
     expect(result).toBe(expectedFileName);
+  });
+
+  it("should build a message with timestamp, log level and message", () => {
+    const result = logger.buildMessage({ message: "Oops" });
+    const expectedResult = {
+      message: "Oops",
+      timestamp: "2019-04-07T10:20:30.000Z",
+      level: "INFO",
+    };
+
+    expect(result).toStrictEqual(expectedResult);
   });
 });

--- a/__tests__/test-helpers.ts
+++ b/__tests__/test-helpers.ts
@@ -9,7 +9,7 @@ import { readdir, readFile } from "fs";
 
 /**
  * reads file at given test filepath
- * @param {string} testFilePath - the test file's filepath
+ * @param testFilePath - the test file's filepath
  * @returns a promise
  */
 function doReadFile(testFilePath: string): Promise<string> {
@@ -27,7 +27,7 @@ function doReadFile(testFilePath: string): Promise<string> {
 
 /**
  * reads contents of given directory
- * @param {string} dirPath - the test directory path
+ * @param dirPath - the test directory path
  * @returns a promise
  */
 function doReadDir(dirPath: string): Promise<string[]> {

--- a/src/simple-logger.ts
+++ b/src/simple-logger.ts
@@ -1,14 +1,26 @@
 import { writeFile } from "fs";
 
+enum LogLevel {
+  INFO = "INFO",
+}
+
+/**
+ * @interface MessageTemplate - template for a SimpleLogger message
+ */
 interface MessageTemplate {
+  /** timestamp in UTC ISODate format */
+  timestamp?: string;
+  /** log level, by default 'INFO' */
+  level?: LogLevel;
+  /** actual text message */
   message: string;
 }
 
 export default {
   /**
    * Build a file name from a date time string and a temporary file name
-   * @param {string} dateTime - a datetime string in YYYY-MM-DD format
-   * @param {string | null} fileName - the temporary file name
+   * @param dateTime - a datetime string in YYYY-MM-DD format
+   * @param fileName - the temporary file name with 'my_file' as default
    * @returns a string in the format of 'my_file-YYYY-MM-DD'
    */
   buildFileName(dateTime: string, fileName: string | null): string {
@@ -21,18 +33,27 @@ export default {
 
   /**
    * Build a file path from the log directory path and the file name
-   * @param {string} logsDir - the absolute path to the logs directory
-   * @param {string} fileName - the name of the file
+   * @param logsDir - the absolute path to the logs directory
+   * @param fileName - the name of the file
    * @returns an absolute path for the file path of the log file
    */
   buildFilePath(logsDir: string, fileName: string): string {
     return `${logsDir}/${fileName}`;
   },
 
+  buildMessage(messageTemplate: MessageTemplate): MessageTemplate {
+    const timestamp: Date = new Date(Date.now());
+
+    messageTemplate.timestamp = timestamp.toISOString();
+    messageTemplate.level = LogLevel.INFO;
+
+    return messageTemplate;
+  },
+
   /**
    * Main function for writing a message to a file
-   * @param {string} filePath - absolute path to where file will be written
-   * @param {string} messageTemplate - message written in file
+   * @param filePath - absolute path to where file will be written
+   * @param messageTemplate - message written in file
    * @returns a Promise containing the message
    */
   triggerLogger(
@@ -40,6 +61,7 @@ export default {
     messageTemplate: MessageTemplate
   ): Promise<string> {
     console.log(messageTemplate.message);
+    messageTemplate = this.buildMessage(messageTemplate);
 
     return new Promise((resolve, reject) => {
       writeFile(


### PR DESCRIPTION
Template is now added so that we have the following:
```
{
  "timestamp": <timestamp in UTC ISODate format>,
  "level": "INFO",
  "message": <message>
}
```
At the moment, we only have the default level of logging: `INFO`