### PR TITLE
feat(basic): Add logging level to file write.

### DIFF
--- a/.github/workflows/node-2.yml
+++ b/.github/workflows/node-2.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/__tests__/level-selector.spec.ts
+++ b/__tests__/level-selector.spec.ts
@@ -1,0 +1,36 @@
+import { LogLevels } from "../src/enums/log-levels";
+import { LevelSelector } from "../src/logging-resources/level-selector";
+
+describe("#LevelSelector", () => {
+  it("should return true if logger level is DEBUG and message level is DEBUG", () => {
+    const levelSelector: LevelSelector = new LevelSelector(LogLevels.DEBUG);
+
+    const result = levelSelector.checkLevel(LogLevels.DEBUG);
+
+    expect(result).toBe(true);
+  });
+
+  it("should return true if logger level is DEBUG and message level is ERROR", () => {
+    const levelSelector: LevelSelector = new LevelSelector(LogLevels.DEBUG);
+
+    const result = levelSelector.checkLevel(LogLevels.ERROR);
+
+    expect(result).toBe(true);
+  });
+
+  it("should return false if logger level is ERROR and message level is WARNING", () => {
+    const levelSelector: LevelSelector = new LevelSelector(LogLevels.ERROR);
+
+    const result = levelSelector.checkLevel(LogLevels.WARNING);
+
+    expect(result).toBe(false);
+  });
+
+  it("should return true if logger level is ERROR and message level is ERROR", () => {
+    const levelSelector: LevelSelector = new LevelSelector(LogLevels.ERROR);
+
+    const result = levelSelector.checkLevel(LogLevels.ERROR);
+
+    expect(result).toBe(true);
+  });
+});

--- a/src/logging-resources/level-selector.ts
+++ b/src/logging-resources/level-selector.ts
@@ -1,0 +1,45 @@
+/**
+ * LevelSelector class module, handles everything related to levels
+ *
+ * @author R.Wood
+ * Date: 11/12/2020
+ */
+
+import { LogLevels } from "../enums/log-levels";
+
+/**
+ * @class LevelSelector
+ *
+ * Determines whether level of message entails writing it to a file
+ *
+ * @property level - DEBUG, INFO, WARNING, or ERROR
+ * @property levelOrder (static and private) - an array showing priority of writing to file based on level (DEBUG is most permissive, ERROR is most restrictive)
+ */
+export class LevelSelector {
+  level: LogLevels;
+  private static levelOrder: LogLevels[] = [
+    LogLevels.DEBUG,
+    LogLevels.INFO,
+    LogLevels.WARNING,
+    LogLevels.ERROR,
+  ];
+
+  constructor(level: LogLevels) {
+    this.level = level;
+  }
+
+  /**
+   * Check level in message against level in logger
+   * @param levelToCheck - the level of the message
+   * @returns true if the logger should write to file, false if not
+   */
+  checkLevel(levelToCheck: LogLevels | undefined): boolean {
+    if (!levelToCheck) {
+      levelToCheck = LogLevels.INFO;
+    }
+    return LevelSelector.levelOrder.indexOf(levelToCheck) >=
+      LevelSelector.levelOrder.indexOf(this.level)
+      ? true
+      : false;
+  }
+}


### PR DESCRIPTION
Add logging level to file write.

If logger accepts DEBUG level messages, for example, it will write out all message levels available in SimpleLogger.

If logger accepts ERROR level messages, for example, it will write out only ERROR messages and log to console all other message levels.

Linked to issue #8 